### PR TITLE
CDS ID assignment fix

### DIFF
--- a/R/method_incorporateGenomicMutations.R
+++ b/R/method_incorporateGenomicMutations.R
@@ -328,7 +328,7 @@ incorporateGenomicVariants <- function(ProteoDiscography, aggregateSamples = FAL
         Tx.CDS.Current.SequenceWT.tmp <- Tx.CDS.Current.SequenceWT
 
         # Mutant sequence of current CDS.
-        mutCDS <- S4Vectors::unique(mutantCDS.currentSample.currentTx$CDS.SequenceMut)
+        mutCDS <- mutantCDS.currentSample.currentTx[mutantCDS.currentSample.currentTx$CDS.ID %in% S4Vectors::unique(mutantCDS.currentSample.currentTx$CDS.ID), ]$CDS.SequenceMut
         base::names(mutCDS) <- S4Vectors::unique(mutantCDS.currentSample.currentTx$CDS.ID)
 
         # If only a single CDS per exon can be replaced.


### PR DESCRIPTION
In certain cases, when identical sequences with different CDS IDs were present, the number of sequences/names would be asymmetrical and cause issues.